### PR TITLE
feat(prefecture): 2. API レスポンスから都道府県一覧のチェックボックスを動的に生成する

### DIFF
--- a/src/components/PrefectureCheckBox.vue
+++ b/src/components/PrefectureCheckBox.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="prefecture-check-box">
+    <input
+      :id="prefCode"
+      type="checkbox"
+      v-model="value"
+      @change="selectedPrefecture"
+    />
+    <label :for="prefCode">{{ prefName }}</label>
+  </div>
+</template>
+<script lang="ts">
+import { Vue, Component, Prop, Emit } from "vue-property-decorator";
+import PrefectureCheckBoxParameter from "@/models/PrefectureCheckBoxParameter";
+
+@Component({})
+export default class PrefectureCheckBox extends Vue {
+  @Prop({ default: [] })
+  prefCode?: number;
+
+  @Prop()
+  prefName?: string;
+
+  public value = false;
+
+  @Emit("selectedPrefecture")
+  selectedPrefecture() {
+    return { prefCode: this.prefCode, checked: this.value };
+  }
+}
+</script>
+<style>
+.prefecture-check-box {
+  font-size: 24px;
+  margin: 0 5px;
+}
+</style>

--- a/src/components/PrefectureCheckBoxes.vue
+++ b/src/components/PrefectureCheckBoxes.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="prefecture-check-boxes">
+    <template v-for="prefecture in prefetureList">
+      <prefecture-check-box
+        :key="prefecture.prefCode"
+        :prefCode="prefecture.prefCode"
+        :prefName="prefecture.prefName"
+        @selectedPrefecture="selectedPrefecture"
+      ></prefecture-check-box>
+    </template>
+  </div>
+</template>
+<script lang="ts">
+import Prefecture from "@/models/Prefecture";
+import { Vue, Component, Prop, Emit } from "vue-property-decorator";
+import PrefectureCheckBox from "@/components/PrefectureCheckBox.vue";
+import PrefectureCheckBoxParameter from "@/models/PrefectureCheckBoxParameter";
+
+@Component({
+  components: {
+    PrefectureCheckBox,
+  },
+})
+export default class PrefectureCheckBoxes extends Vue {
+  @Prop({ default: [] })
+  prefetureList?: Prefecture[];
+
+  @Emit("selectedPrefecture")
+  selectedPrefecture(value: PrefectureCheckBoxParameter) {
+    return value;
+  }
+}
+</script>
+<style>
+.prefecture-check-boxes {
+  width: 600px;
+  font-size: 24px;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.prefecture-check-box {
+  margin: 0 5px;
+}
+</style>

--- a/src/models/PrefectureCheckBoxParameter.ts
+++ b/src/models/PrefectureCheckBoxParameter.ts
@@ -1,0 +1,4 @@
+export default interface PrefectureCheckBoxParameter {
+  preCode: number;
+  checked: boolean;
+}

--- a/src/views/PrefecturePage.vue
+++ b/src/views/PrefecturePage.vue
@@ -1,17 +1,33 @@
 <template>
-  <div></div>
+  <div>
+    <prefecture-check-boxes
+      :prefetureList="prefectureList"
+      @selectedPrefecture="getPrefectureCode"
+    ></prefecture-check-boxes>
+  </div>
 </template>
 <script lang="ts">
 import { Vue, Component } from "vue-property-decorator";
+import PrefectureCheckBoxes from "@/components/PrefectureCheckBoxes.vue";
 import prefectureAPI from "@/api/prefecture";
 import Prefecture from "@/models/Prefecture.ts";
+import prefecture from "@/api/prefecture";
+import PrefectureCheckBoxParameter from "@/models/PrefectureCheckBoxParameter";
 
-@Component({})
+@Component({
+  components: {
+    PrefectureCheckBoxes,
+  },
+})
 export default class PrefecturePage extends Vue {
-  public prefectureList?: Prefecture[];
+  public prefectureList?: Prefecture[] = [];
 
   async created() {
     this.prefectureList = await prefectureAPI.getPrefectureList();
+  }
+
+  getPrefectureCode(value: PrefectureCheckBoxParameter) {
+    return value;
   }
 }
 </script>


### PR DESCRIPTION
# 2. API レスポンスから都道府県一覧のチェックボックスを動的に生成する

RESAS API の「都道府県一覧」から API を取得した都道府県一覧のチェックボックス
を動的に生成し表示するコンポーネントの作成

* APIで取得した都道府県の数だけチェックボックスを動的に生成する
* チェックボックスをクリックすると、valueと都道府県コードを伝播する

|名前|イメージ|
|---|---|
|追加後|![Screenshot from 2021-03-02 03-46-25](https://user-images.githubusercontent.com/38244340/109544396-de09b680-7b0a-11eb-9c71-2ecdfecd9a4c.png)|

## API

### 新規

なし

## models

@/models/PrefectureCheckBoxParameter.ts

```
PrefectureCheckBoxParameter

prefCode:number
checked:boolean

```

## components・pages

@/components/PrefectureCheckBox.vue

```
@Prop()
prefCode:number

@Prop()
prefName:string

@Emit('selectedPrefecture'):PrefectureCheckBoxParameter

```

@/components/PrefectureCheckBoxes.vue

```
@Prop()
prefectures: Prefecture[]

@Emit('selectedPrefecture'):PrefectureCheckBoxParameter

```
