### PR TITLE
feat(prefecture): 3. 都道府県にチェックを入れると、RESAS APIから選択された都道府県の「人口構成」を取得する

### DIFF
--- a/src/api/prefecture.ts
+++ b/src/api/prefecture.ts
@@ -1,9 +1,19 @@
 import axios from "axios";
 import Prefecture from "@/models/Prefecture.ts";
+import PrefecturePopulationComposition from "@/models/PrefecturePopulationComposition";
 
 export default {
   async getPrefectureList(): Promise<Prefecture[]> {
     const res = await axios.get("/api/v1/prefectures");
     return res["data"]["result"];
+  },
+
+  async getPrefecturePopulationComposition(
+    prefCode: number
+  ): Promise<PrefecturePopulationComposition> {
+    const res = await axios.get(
+      `api/v1/population/composition/perYear?prefCode=${prefCode}`
+    );
+    return res["data"]["result"]["data"];
   },
 };

--- a/src/models/PrefectureCheckBoxParameter.ts
+++ b/src/models/PrefectureCheckBoxParameter.ts
@@ -1,4 +1,4 @@
 export default interface PrefectureCheckBoxParameter {
-  preCode: number;
+  prefCode: number;
   checked: boolean;
 }

--- a/src/models/PrefecturePopulation.ts
+++ b/src/models/PrefecturePopulation.ts
@@ -1,0 +1,4 @@
+export default interface PrefecturePopulationComposition {
+  year: number;
+  value: number;
+}

--- a/src/models/PrefecturePopulationComposition.ts
+++ b/src/models/PrefecturePopulationComposition.ts
@@ -1,0 +1,6 @@
+import PrefecturePopulation from "@/models/PrefecturePopulation";
+
+export default interface PrefecturePopulationComposition {
+  label: string;
+  data: PrefecturePopulation[];
+}

--- a/src/views/PrefecturePage.vue
+++ b/src/views/PrefecturePage.vue
@@ -11,8 +11,8 @@ import { Vue, Component } from "vue-property-decorator";
 import PrefectureCheckBoxes from "@/components/PrefectureCheckBoxes.vue";
 import prefectureAPI from "@/api/prefecture";
 import Prefecture from "@/models/Prefecture.ts";
-import prefecture from "@/api/prefecture";
 import PrefectureCheckBoxParameter from "@/models/PrefectureCheckBoxParameter";
+import PrefecturePopulationComposition from "@/models/PrefecturePopulationComposition";
 
 @Component({
   components: {
@@ -21,13 +21,24 @@ import PrefectureCheckBoxParameter from "@/models/PrefectureCheckBoxParameter";
 })
 export default class PrefecturePage extends Vue {
   public prefectureList?: Prefecture[] = [];
+  public prefecturePopulationComposition?: PrefecturePopulationComposition;
 
   async created() {
-    this.prefectureList = await prefectureAPI.getPrefectureList();
+    try {
+      this.prefectureList = await prefectureAPI.getPrefectureList();
+    } catch (err) {
+      alert("都道府県一覧の取得に失敗しました");
+    }
   }
 
-  getPrefectureCode(value: PrefectureCheckBoxParameter) {
-    return value;
+  async getPrefectureCode(value: PrefectureCheckBoxParameter) {
+    try {
+      this.prefecturePopulationComposition = await prefectureAPI.getPrefecturePopulationComposition(
+        value.prefCode
+      );
+    } catch (err) {
+      alert("人口構成の取得に失敗しました");
+    }
   }
 }
 </script>


### PR DESCRIPTION
# 3. 都道府県にチェックを入れると、RESAS API から選択された都道府県の「人口構成」を取得する

チェックボックスが押下された時、都道府県コードを使い都道府県の「人口構成」を取得する

* チェックボックスの値が更新された時、Emitされ、渡されたprefCodeを使いAPIをコールする


## API

### 新規

| メソッド名                                          | URL                                                   |
| --------------------------------------------------- | ----------------------------------------------------- |
| getPrefecturePopulationComposition(prefCode:number) | GET api/v1/population/composition/perYear/${prefCode} |

## models

@models/PrefecturePopulationComposition

```
PrefecturePopulationComposition

label: number
data :PrefecturePopulation

```

@/models/PrefecturePopulation

```
PrefecturePopulation

year: number
value: number


```

## components・pages

なし