### PR TITLE
feat(prefecture): 4. 人口構成APIレスポンスから、X軸:年、Y軸:人口数の折れ線グラフを動的に生成して表示する

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "chart.js": "^2.9.4",
     "core-js": "^3.6.5",
     "vue": "^2.6.11",
+    "vue-chartjs": "^3.5.1",
     "vue-class-component": "^7.2.3",
     "vue-property-decorator": "^9.1.2",
     "vue-router": "^3.2.0",

--- a/src/components/PrefectureChart.vue
+++ b/src/components/PrefectureChart.vue
@@ -1,0 +1,15 @@
+<script lang="ts">
+import { Vue, Component, Prop, Mixins } from "vue-property-decorator";
+import Chart from "chart.js";
+import { Line, Bar, mixins } from "vue-chartjs";
+
+@Component({})
+export default class PrefectureChart extends Mixins(Line, mixins.reactiveProp) {
+  @Prop()
+  options?: any;
+
+  mounted() {
+    this.renderChart(this.chartData, this.options);
+  }
+}
+</script>

--- a/src/components/PrefectureChartGroup.vue
+++ b/src/components/PrefectureChartGroup.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="prefecture-chart-container">
+    <prefecture-chart :chartData="upsertChartData"></prefecture-chart>
+  </div>
+</template>
+<script lang="ts">
+import { Vue, Component, Prop, Watch } from "vue-property-decorator";
+import PrefectureChart from "@/components/PrefectureChart.vue";
+import PrefecturePopulationChartData from "@/models/PrefecturePopulationChartData";
+
+@Component({
+  components: {
+    PrefectureChart,
+  },
+})
+export default class PrefectureChartGroup extends Vue {
+  @Prop({})
+  items?: PrefecturePopulationChartData;
+
+  get upsertChartData() {
+    return JSON.parse(JSON.stringify(this.items));
+  }
+}
+</script>
+<style>
+.prefecture-chart-container {
+  width: 500px;
+  height: 300px;
+  margin: 50px 0;
+}
+</style>

--- a/src/components/PrefectureCheckBox.vue
+++ b/src/components/PrefectureCheckBox.vue
@@ -25,7 +25,11 @@ export default class PrefectureCheckBox extends Vue {
 
   @Emit("selectedPrefecture")
   selectedPrefecture() {
-    return { prefCode: this.prefCode, checked: this.value };
+    return {
+      prefCode: this.prefCode,
+      prefName: this.prefName,
+      checked: this.value,
+    };
   }
 }
 </script>

--- a/src/models/PrefectureCheckBoxParameter.ts
+++ b/src/models/PrefectureCheckBoxParameter.ts
@@ -1,4 +1,5 @@
 export default interface PrefectureCheckBoxParameter {
   prefCode: number;
+  prefName: string;
   checked: boolean;
 }

--- a/src/models/PrefecturePopulationChartData.ts
+++ b/src/models/PrefecturePopulationChartData.ts
@@ -1,0 +1,6 @@
+import PrefecturePopulationChartDataset from "@/models/PrefecturePopulationChartDataset";
+
+export default interface PrefecturePopulationGraphData {
+  labels: number[];
+  datasets: PrefecturePopulationChartDataset[];
+}

--- a/src/models/PrefecturePopulationChartDataset.ts
+++ b/src/models/PrefecturePopulationChartDataset.ts
@@ -1,0 +1,6 @@
+export default interface PrefecturePopulationChartDataset {
+  label: string;
+  data: number[];
+  fill: boolean;
+  lineTension: number;
+}

--- a/src/views/PrefecturePage.vue
+++ b/src/views/PrefecturePage.vue
@@ -4,24 +4,33 @@
       :prefetureList="prefectureList"
       @selectedPrefecture="getPrefectureCode"
     ></prefecture-check-boxes>
+    <prefecture-chart-group :items="prefecturePopulationChartData" />
   </div>
 </template>
 <script lang="ts">
 import { Vue, Component } from "vue-property-decorator";
 import PrefectureCheckBoxes from "@/components/PrefectureCheckBoxes.vue";
+import PrefectureChartGroup from "@/components/PrefectureChartGroup.vue";
 import prefectureAPI from "@/api/prefecture";
 import Prefecture from "@/models/Prefecture.ts";
 import PrefectureCheckBoxParameter from "@/models/PrefectureCheckBoxParameter";
 import PrefecturePopulationComposition from "@/models/PrefecturePopulationComposition";
+import PrefecturePopulation from "@/models/PrefecturePopulation";
+import PrefecturePopulationChartData from "@/models/PrefecturePopulationChartData";
 
 @Component({
   components: {
     PrefectureCheckBoxes,
+    PrefectureChartGroup,
   },
 })
 export default class PrefecturePage extends Vue {
   public prefectureList?: Prefecture[] = [];
   public prefecturePopulationComposition?: PrefecturePopulationComposition;
+  public prefecturePopulationChartData: PrefecturePopulationChartData = {
+    labels: [],
+    datasets: [],
+  };
 
   async created() {
     try {
@@ -33,12 +42,27 @@ export default class PrefecturePage extends Vue {
 
   async getPrefectureCode(value: PrefectureCheckBoxParameter) {
     try {
-      this.prefecturePopulationComposition = await prefectureAPI.getPrefecturePopulationComposition(
+      const res = await prefectureAPI.getPrefecturePopulationComposition(
         value.prefCode
       );
+      this.addPrefecturePopulationChartDataset(value.prefName, res[0].data);
     } catch (err) {
       alert("人口構成の取得に失敗しました");
     }
+  }
+
+  addPrefecturePopulationChartDataset(
+    prefName: string,
+    items: PrefecturePopulation[]
+  ) {
+    const dataset = {
+      label: prefName,
+      data: items.map((item) => item.value),
+      fill: false,
+      lineTension: 0,
+    };
+    this.prefecturePopulationChartData.labels = items.map((item) => item.year);
+    this.prefecturePopulationChartData.datasets.push(dataset);
   }
 }
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,6 +941,13 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/chart.js@^2.7.55":
+  version "2.9.31"
+  resolved "https://registry.yarnpkg.com/@types/chart.js/-/chart.js-2.9.31.tgz#e8ebc7ed18eb0e5114c69bd46ef8e0037c89d39d"
+  integrity sha512-hzS6phN/kx3jClk3iYqEHNnYIRSi4RZrIGJ8CDLjgatpHoftCezvC44uqB3o3OUm9ftU1m7sHG8+RLyPTlACrA==
+  dependencies:
+    moment "^2.10.2"
+
 "@types/connect-history-api-fallback@*":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.3.tgz#4772b79b8b53185f0f4c9deab09236baf76ee3b4"
@@ -2433,6 +2440,29 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+chart.js@^2.9.4:
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.9.4.tgz#0827f9563faffb2dc5c06562f8eb10337d5b9684"
+  integrity sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==
+  dependencies:
+    chartjs-color "^2.1.0"
+    moment "^2.10.2"
+
+chartjs-color-string@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz#1df096621c0e70720a64f4135ea171d051402f71"
+  integrity sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==
+  dependencies:
+    color-name "^1.0.0"
+
+chartjs-color@^2.1.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.4.1.tgz#6118bba202fe1ea79dd7f7c0f9da93467296c3b0"
+  integrity sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==
+  dependencies:
+    chartjs-color-string "^0.6.0"
+    color-convert "^1.9.3"
+
 check-types@^8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
@@ -2613,7 +2643,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0, color-convert@^1.9.1:
+color-convert@^1.9.0, color-convert@^1.9.1, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -5717,6 +5747,11 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+moment@^2.10.2:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -8436,6 +8471,13 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vue-chartjs@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/vue-chartjs/-/vue-chartjs-3.5.1.tgz#d25e845708f7744ae51bed9d23a975f5f8fc6529"
+  integrity sha512-foocQbJ7FtveICxb4EV5QuVpo6d8CmZFmAopBppDIGKY+esJV8IJgwmEW0RexQhxqXaL/E1xNURsgFFYyKzS/g==
+  dependencies:
+    "@types/chart.js" "^2.7.55"
 
 vue-class-component@^7.2.3:
   version "7.2.6"


### PR DESCRIPTION
# 4. 人口構成 API レスポンスから、X 軸:年、Y 軸:人口数の折れ線グラフを動的に生成して表示する

人口構成 API レスポンスを受け取り、グラフを動的に生成するコンポーネントの作成

* グラフを表示することができる
* X:年、Y:人口を表示することができる
* 複数の都道府県の人口構成をグラフに描画できる

| 名前 | イメージ |
| ---- | -------- |
|  追加前    |  ![Screenshot from 2021-03-02 03-46-25](https://user-images.githubusercontent.com/38244340/109689649-dc9ec380-7bc8-11eb-8b0c-388881c50712.png)|
|  追加後    |   ![Screenshot from 2021-03-03 02-25-49](https://user-images.githubusercontent.com/38244340/109689666-e32d3b00-7bc8-11eb-8e4f-3f157598ab19.png) |

## API

### 新規

追加なし

## models

- 新規

@/models/PrefecturePopulationChartData.ts

```
PrefecturePopulationChartData

labels: number[];
datasets: PrefecturePopulationChartDataset[];
```

@/models/PrefecturePopulationChartDataset.ts

```
PrefecturePopulationChartDataset

label: string;
data: number[];
fill: boolean;
lineTension: number;

```

- 追加
  @/models/prefectureCheckBoxParameter.ts

```
prefectureCheckBoxParameter

prefName: string
```

## component・pages

@/components/PrefectureChart.vue

```
PrefectureChart

@Prop()
options
```

@/components/PrefectureChartGroup.vue

```
PrefectureChartGroup

@Prop()
items:prefecturePopulationChartData
```

@/views/PrefecturePage.vue

```
prefecturePopulationChartData :prefecturePopulationChartData
```
