### PR TITLE
feat(prefecture): チェックをoffにした都道府県のグラフを削除することができる

### DIFF
--- a/src/views/PrefecturePage.vue
+++ b/src/views/PrefecturePage.vue
@@ -41,6 +41,10 @@ export default class PrefecturePage extends Vue {
   }
 
   async getPrefectureCode(value: PrefectureCheckBoxParameter) {
+    if (!value.checked) {
+      this.removePrefecturePopulationChartDataset(value.prefName);
+      return;
+    }
     try {
       const res = await prefectureAPI.getPrefecturePopulationComposition(
         value.prefCode
@@ -63,6 +67,12 @@ export default class PrefecturePage extends Vue {
     };
     this.prefecturePopulationChartData.labels = items.map((item) => item.year);
     this.prefecturePopulationChartData.datasets.push(dataset);
+  }
+
+  removePrefecturePopulationChartDataset(prefName: string) {
+    this.prefecturePopulationChartData.datasets = this.prefecturePopulationChartData.datasets.filter(
+      (item) => item.label != prefName
+    );
   }
 }
 </script>


### PR DESCRIPTION
# チェックを off にした都道府県のグラフを削除することができる

すでにチェックされている都道府県のチェックボックスを押下した時  
chart から対応する都道府県の折れ線グラフを削除する

| 名前   | イメージ |
| ------ | -------- |
| 追加前 |  ![Peek 2021-03-03 03-06](https://user-images.githubusercontent.com/38244340/109694317-01e20080-7bce-11eb-87ae-9ef13a610c29.gif)  |
| 追加後 |  ![Peek 2021-03-03 03-05](https://user-images.githubusercontent.com/38244340/109694349-0efeef80-7bce-11eb-8c88-ac73dd950e22.gif) |

## API

### 新規

追加なし

## models

### 新規

追加なし

## component・pages

追加なし
