### PR TITLE
feat(prefecture): 都道府県のグラフごとに色を分ける機能の追加

### DIFF
--- a/src/common/color.ts
+++ b/src/common/color.ts
@@ -1,0 +1,3 @@
+export const generateColorCode = () => {
+  return "#" + Math.floor(Math.random() * 16777215).toString(16);
+};

--- a/src/models/PrefecturePopulationChartDataset.ts
+++ b/src/models/PrefecturePopulationChartDataset.ts
@@ -3,4 +3,5 @@ export default interface PrefecturePopulationChartDataset {
   data: number[];
   fill: boolean;
   lineTension: number;
+  borderColor: string;
 }

--- a/src/views/PrefecturePage.vue
+++ b/src/views/PrefecturePage.vue
@@ -17,6 +17,7 @@ import PrefectureCheckBoxParameter from "@/models/PrefectureCheckBoxParameter";
 import PrefecturePopulationComposition from "@/models/PrefecturePopulationComposition";
 import PrefecturePopulation from "@/models/PrefecturePopulation";
 import PrefecturePopulationChartData from "@/models/PrefecturePopulationChartData";
+import { generateColorCode } from "@/common/color";
 
 @Component({
   components: {
@@ -64,6 +65,7 @@ export default class PrefecturePage extends Vue {
       data: items.map((item) => item.value),
       fill: false,
       lineTension: 0,
+      borderColor: generateColorCode(),
     };
     this.prefecturePopulationChartData.labels = items.map((item) => item.year);
     this.prefecturePopulationChartData.datasets.push(dataset);


### PR DESCRIPTION
# 都道府県のグラフごとに色を分ける機能の追加

都道府県の総人口の折れ線グラフを追加した時、折れ線グラフに
ランダムにカラーコードを追加する

| 名前   | イメージ |
| ------ | -------- |
| 追加前 |   ![Screenshot from 2021-03-03 02-25-49](https://user-images.githubusercontent.com/38244340/109697252-4e7b0b00-7bd1-11eb-8cb9-a4a983211c63.png)       |
| 追加後 |   ![Screenshot from 2021-03-03 03-27-19](https://user-images.githubusercontent.com/38244340/109697280-563aaf80-7bd1-11eb-874f-8af36e0f9fe9.png) |
## API

### 新規

追加なし

## models

### 新規

追加なし

### 追加

@/models/PrefecturePopulationComposition.ts

```
PrefecturePopulationComposition

borderColor: string
```

## component・pages

追加なし
