### PR TITLE
feat(prefecture): スマートフォンサイズ(678px)のレスポンシブ対応

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,17 +13,4 @@
   text-align: center;
   color: #2c3e50;
 }
-
-#nav {
-  padding: 30px;
-}
-
-#nav a {
-  font-weight: bold;
-  color: #2c3e50;
-}
-
-#nav a.router-link-exact-active {
-  color: #42b983;
-}
 </style>

--- a/src/components/PrefectureChartGroup.vue
+++ b/src/components/PrefectureChartGroup.vue
@@ -32,6 +32,13 @@ export default class PrefectureChartGroup extends Vue {
 .prefecture-chart-container {
   width: 500px;
   height: 200px;
-  margin: 50px 0;
+  margin: 50px auto;
+}
+
+@media screen and (max-width: 678px) {
+  .prefecture-chart-container {
+    width: 100%;
+    height: auto;
+  }
 }
 </style>

--- a/src/components/PrefectureCheckBox.vue
+++ b/src/components/PrefectureCheckBox.vue
@@ -38,4 +38,11 @@ export default class PrefectureCheckBox extends Vue {
   font-size: 18px;
   margin: 0 5px;
 }
+
+@media screen and (max-width: 678px) {
+  .prefecture-check-box {
+    font-size: 22px;
+    width: 90px;
+  }
+}
 </style>

--- a/src/components/PrefectureCheckBoxes.vue
+++ b/src/components/PrefectureCheckBoxes.vue
@@ -40,6 +40,13 @@ export default class PrefectureCheckBoxes extends Vue {
 }
 
 .prefecture-check-box {
-  margin: 0 5px;
+  margin: 0 16px;
+}
+
+@media screen and (max-width: 678px) {
+  .prefecture-check-boxes {
+    width: 70%;
+    margin: 0 auto;
+  }
 }
 </style>

--- a/src/components/PrefectureLabel.vue
+++ b/src/components/PrefectureLabel.vue
@@ -2,7 +2,11 @@
   <div>
     <p
       class="label"
-      :style="{ 'font-size': size + 'px', color: color, 'text-align': align }"
+      :style="{
+        'font-size': fontSize + 'px',
+        color: color,
+        'text-align': alignChange,
+      }"
     >
       {{ label }}
     </p>
@@ -17,13 +21,48 @@ export default class PrefectureLabel extends Vue {
   label?: string;
 
   @Prop({ default: 16 })
-  size?: number;
+  size!: number;
 
   @Prop({ default: "black" })
   color?: string;
 
   @Prop()
   align?: string;
+
+  public windowWidth = 0;
+
+  get fontSize() {
+    if (this.windowWidth < 678) {
+      return this.size * 1.5;
+    } else {
+      return this.size;
+    }
+  }
+
+  get alignChange() {
+    if (this.windowWidth < 678) {
+      return "center";
+    } else {
+      return this.align;
+    }
+  }
+
+  mounted() {
+    this.updateWindowWidth();
+    window.addEventListener("resize", this.updateWindowWidth);
+  }
+
+  destory() {
+    window.removeEventListener("resize", this.updateWindowWidth);
+  }
+
+  updateWindowWidth() {
+    this.windowWidth = window.innerWidth;
+  }
 }
 </script>
-<style></style>
+<style>
+.label {
+  margin: 16px;
+}
+</style>

--- a/src/views/PrefecturePage.vue
+++ b/src/views/PrefecturePage.vue
@@ -4,12 +4,16 @@
       text="title"
       size="32"
       backgroundColor="gray"
-      width="550px"
+      width="100%"
       height="100px"
       display="flex"
       justify="center"
     ></prefecture-header>
-    <prefecture-label label="都道府県" align="left"></prefecture-label>
+    <prefecture-label
+      label="都道府県"
+      size="16"
+      align="left"
+    ></prefecture-label>
     <prefecture-check-boxes
       :prefetureList="prefectureList"
       @selectedPrefecture="getPrefectureCode"
@@ -50,6 +54,7 @@ export default class PrefecturePage extends Vue {
     datasets: [],
   };
   public options = {
+    responsive: true,
     maintainAspectRatio: false,
     legend: {
       position: "right",
@@ -136,5 +141,11 @@ export default class PrefecturePage extends Vue {
   min-height: 1000px;
   margin-bottom: 5%;
   border: 1px solid black;
+}
+
+@media screen and (max-width: 678px) {
+  .container {
+    width: 100%;
+  }
 }
 </style>


### PR DESCRIPTION
# feat(prefecture): スマートフォンサイズ(678px)のレスポンシブ対応

スマートフォンでのレスポンシブ対応

* スマートフォン用のCSSの追加
*  動的styleの箇所はPropでなく、getterで渡すようにした

| 追加前  | 追加後 |
| ------ | -------- |
|  ![Screenshot from 2021-03-03 19-18-45](https://user-images.githubusercontent.com/38244340/109791196-81ff7900-7c55-11eb-877b-1bcb3fc6d291.png) | ![Screenshot from 2021-03-03 19-18-17](https://user-images.githubusercontent.com/38244340/109791217-888df080-7c55-11eb-9ada-b2aece18f214.png) |