### PR TITLE
fix(prefecture): 総人口以外の余計なデータを渡してしまう

### DIFF
--- a/src/api/prefecture.ts
+++ b/src/api/prefecture.ts
@@ -14,6 +14,6 @@ export default {
     const res = await axios.get(
       `api/v1/population/composition/perYear?prefCode=${prefCode}`
     );
-    return res["data"]["result"]["data"];
+    return res["data"]["result"]["data"][0];
   },
 };

--- a/src/views/PrefecturePage.vue
+++ b/src/views/PrefecturePage.vue
@@ -95,16 +95,21 @@ export default class PrefecturePage extends Vue {
     }
   }
 
-  async getPrefectureCode(value: PrefectureCheckBoxParameter) {
+  getPrefectureCode(value: PrefectureCheckBoxParameter) {
     if (!value.checked) {
       this.removePrefecturePopulationChartDataset(value.prefName);
       return;
     }
+
+    this.getPrefecturePopulation(value.prefCode, value.prefName);
+  }
+
+  async getPrefecturePopulation(prefCode: number, prefName: string) {
     try {
       const res = await prefectureAPI.getPrefecturePopulationComposition(
-        value.prefCode
+        prefCode
       );
-      this.addPrefecturePopulationChartDataset(value.prefName, res.data);
+      this.addPrefecturePopulationChartDataset(prefName, res.data);
     } catch (err) {
       alert("人口構成の取得に失敗しました");
     }

--- a/src/views/PrefecturePage.vue
+++ b/src/views/PrefecturePage.vue
@@ -33,7 +33,6 @@ import PrefectureChartGroup from "@/components/PrefectureChartGroup.vue";
 import prefectureAPI from "@/api/prefecture";
 import Prefecture from "@/models/Prefecture.ts";
 import PrefectureCheckBoxParameter from "@/models/PrefectureCheckBoxParameter";
-import PrefecturePopulationComposition from "@/models/PrefecturePopulationComposition";
 import PrefecturePopulation from "@/models/PrefecturePopulation";
 import PrefecturePopulationChartData from "@/models/PrefecturePopulationChartData";
 import { generateColorCode } from "@/common/color";
@@ -48,7 +47,6 @@ import { generateColorCode } from "@/common/color";
 })
 export default class PrefecturePage extends Vue {
   public prefectureList?: Prefecture[] = [];
-  public prefecturePopulationComposition?: PrefecturePopulationComposition;
   public prefecturePopulationChartData: PrefecturePopulationChartData = {
     labels: [],
     datasets: [],
@@ -106,7 +104,7 @@ export default class PrefecturePage extends Vue {
       const res = await prefectureAPI.getPrefecturePopulationComposition(
         value.prefCode
       );
-      this.addPrefecturePopulationChartDataset(value.prefName, res[0].data);
+      this.addPrefecturePopulationChartDataset(value.prefName, res.data);
     } catch (err) {
       alert("人口構成の取得に失敗しました");
     }


### PR DESCRIPTION
# fix(prefecture): 総人口以外の余計なデータを渡してしまう

getPrefecturePopulationCompositionを呼び出す時、総人口以外のデータも取得し、まとめて渡してしまっている。
総人口のみをレスポンスから取り出し、返却する。

## API 

|メソッド名 | URL |
| --- | --- |
|getPrefecturePopulationComposition(prefCode: number): Promise<PrefecturePopulationComposition>|GET api/v1/population/composition/perYear?prefCode=${prefCode} |

## models

修正なし
