### PR TITLE
fix(prefecture): parameter名の修正

### DIFF
--- a/src/models/PrefecturePopulation.ts
+++ b/src/models/PrefecturePopulation.ts
@@ -1,4 +1,4 @@
-export default interface PrefecturePopulationComposition {
+export default interface PrefecturePopulation {
   year: number;
   value: number;
 }

--- a/src/models/PrefecturePopulationChartData.ts
+++ b/src/models/PrefecturePopulationChartData.ts
@@ -1,6 +1,6 @@
 import PrefecturePopulationChartDataset from "@/models/PrefecturePopulationChartDataset";
 
-export default interface PrefecturePopulationGraphData {
+export default interface PrefecturePopulationChartData {
   labels: number[];
   datasets: PrefecturePopulationChartDataset[];
 }


### PR DESCRIPTION
# fix(prefecture): parameter名の修正
modelsのパラメータ名のデフォルトがファイル名と異なるため、修正を行った

* PrefecturePopulationChartDataのデフォルト名の修正  
* PrefecturePopulationのデフォルト名の修正

## models

@/models/PrefecturePopulationChartData.ts
@/modelsPrefecturePopulation

